### PR TITLE
Ensure cache directory exists for new app

### DIFF
--- a/lib/hoodie/new.js
+++ b/lib/hoodie/new.js
@@ -108,8 +108,8 @@ CreateCommand.prototype.run = function(options, callback) {
 CreateCommand.prototype.ensureCacheDir = function(options, ctx, callback) {
   if (!fs.existsSync(options.cacheDir)) {
     shell.mkdir('-p', options.cacheDir);
-    return callback(null);
   }
+  return callback(null);
 };
 
 //


### PR DESCRIPTION
Fixes #85 where Git is unable to clone the template into the cache directory (though you run into another error just afterwards).
