### PR TITLE
Use repository name instead of full template string when building Git URL

### DIFF
--- a/lib/hoodie/util/command.js
+++ b/lib/hoodie/util/command.js
@@ -68,7 +68,7 @@ Command.prototype.buildGitURI = function (options) {
   var cProtocol = options.ssh ? protocols[1] : protocols[0];
   var cSeparator = options.ssh ? separator[1] : separator[0];
 
-  return cProtocol + host + cSeparator + options.template.entity + separator[0] + options.template.template + '.git';
+  return cProtocol + host + cSeparator + options.template.entity + separator[0] + options.template.repo + '.git';
 };
 
 


### PR DESCRIPTION
Consider command `hoodie new project thiagofelix/hoodie-angular`
Without a fix, it resulted in the following error:

```
Could not fetch project from https://github.com/thiagofelix/thiagofelix/hoodie-angular.git
something went wrong...
```
