### PR TITLE
Add appveyor testing

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,6 @@ init:
 environment:
   matrix:
     - nodejs_version: "0.10"
-    - nodejs_version: "0.8"
     - nodejs_version: "0.11"
 
 # Allow failing jobs for bleeding-edge Node.js versions.


### PR DESCRIPTION
Tests will now also be run on Windows. The `appveyor.yml` is mostly copied from [grunt's one](https://github.com/gruntjs/grunt/blob/master/appveyor.yml).
