### PR TITLE
[fix] don't mess up template in cache folder. Fixes #103

### DIFF
--- a/lib/hoodie/new.js
+++ b/lib/hoodie/new.js
@@ -16,6 +16,9 @@ function CreateCommand() {
 
 util.inherits(CreateCommand, Command);
 
+function appDir(options) {
+  return path.join(options.cwd, options.name);
+}
 
 //
 // Create a New App.
@@ -99,8 +102,6 @@ CreateCommand.prototype.run = function(options, callback) {
     options.gitArgs.push('--verbose');
   }
 
-  options.rmArg = options.cacheDir + options.template.repo + '/.git';
-
   // optional callback
   callback = callback || function() {};
 
@@ -147,7 +148,33 @@ CreateCommand.prototype.fetch = function (options, ctx, callback) {
 
 };
 
+//
+// Copy template directory to target location.
+//
+Command.prototype.copyToCwd = function (options, ctx, callback) {
 
+  var self = ctx;
+  var srcDir = options.cacheDir + options.template.repo;
+  var targetDir = appDir(options);
+
+  try {
+    shell.mkdir('-p', path.dirname(targetDir));
+  } catch(e) {
+    self.hoodie.emit('err', 'directory already exists');
+    return callback(new Error());
+  }
+
+  try {
+    self.hoodie.emit('info', 'preparing ' + options.name + ' ...');
+    shell.cp('-R', srcDir + '/.', targetDir);
+  } catch(err) {
+    callback(err);
+    return;
+  }
+
+  callback(null);
+
+};
 
 //
 // cleanup after 'git clone' - removes .git folder.
@@ -158,7 +185,8 @@ CreateCommand.prototype.cleanup = function(options, ctx, callback) {
 
   if (!options.keep) {
 
-    rmrf(options.rmArg, function(err) {
+    var dotGit = appDir(options) + '/.git';
+    rmrf(dotGit, function(err) {
 
       if (err) {
         self.hoodie.emit('warn', 'Could not remove folder:');
@@ -182,10 +210,11 @@ CreateCommand.prototype.rename = function (options, ctx, callback) {
 
   var self = ctx;
 
-  process.chdir(options.cacheDir + options.template.repo);
+  process.chdir(appDir(options));
 
   // Replace {{hoodie_appname}} in package.json and www/index.html
   var readFile = function(file) {
+
     return fs.readFileSync(file)
       .toString()
       .replace(/\{\{hoodie_appname\}\}/gi, options.name);
@@ -210,7 +239,6 @@ CreateCommand.prototype.rename = function (options, ctx, callback) {
 
 };
 
-
 //
 // Install npm dependencies
 //
@@ -218,7 +246,7 @@ CreateCommand.prototype.deps = function (options, ctx, callback) {
 
   var self = ctx;
 
-  process.chdir(options.cacheDir + options.template.repo);
+  process.chdir(appDir(options));
 
   self.hoodie.emit('info', 'fetching npm dependencies');
 
@@ -239,36 +267,6 @@ CreateCommand.prototype.deps = function (options, ctx, callback) {
 
 };
 
-
-//
-// Move template to cwd.
-//
-Command.prototype.copyToCwd = function (options, ctx, callback) {
-
-  var self = ctx;
-  var srcDir = options.cacheDir + options.template.repo;
-  var targetDir = path.join(options.cwd, options.name);
-
-  try {
-    shell.mkdir('-p', path.dirname(targetDir));
-  } catch(e) {
-    self.hoodie.emit('err', 'directory already exists');
-    return callback(new Error());
-  }
-
-  try {
-    self.hoodie.emit('info', 'preparing ' + options.name + ' ...');
-    shell.cp('-R', srcDir + '/.', targetDir);
-  } catch(err) {
-    callback(err);
-    return;
-  }
-
-  callback(null);
-
-};
-
-
 //
 // Execute.
 //
@@ -279,10 +277,10 @@ CreateCommand.prototype.execute = function (options) {
   async.applyEachSeries([
     dirUtils.ensureCacheDir,
     self.fetch,
+    self.copyToCwd,
     self.cleanup,
     self.rename,
-    self.deps,
-    self.copyToCwd
+    self.deps
   ], options, self, function (err) {
 
     if (err) {
@@ -316,7 +314,6 @@ CreateCommand.prototype.execute = function (options) {
   });
 
 };
-
 
 module.exports = {
   exec: function (hoodie) {


### PR DESCRIPTION
Changes the order of actions when creating a new app from a template, so that the template is copied first and all other actions (replacement of placeholder strings etc.) are done in the new app directory, not in the cached template directory.

Sorry, the diff looks larger than necessary because I moved `copyToCwd` up so that the order in which the methods are declared still matches the order in the `async.applyEachSeries` call.

Fixes #103
