### PR TITLE
Install template from cache only

### DIFF
--- a/lib/hoodie/new.js
+++ b/lib/hoodie/new.js
@@ -8,6 +8,7 @@ var async = require('async');
 var path = require('path');
 var shell = require('shelljs');
 var npm = require('npm');
+var StdOutFixture = require('fixture-stdout');
 
 function CreateCommand() {
   return Command.apply(this, arguments);
@@ -86,12 +87,74 @@ Command.prototype.mkdir = function (options, ctx, callback) {
 
 };
 
-
-CreateCommand.prototype.fetch = function (options, ctx, callback) {
+CreateCommand.prototype.checkCache = function (options, ctx, callback) {
 
   var self = ctx;
 
-  self.hoodie.emit('info', 'Fetching template via npm. This may take some time.');
+  var registryAvailable = function(npm, callback) {
+    var host = npm.registry.registry.replace(/https+:\/\/|\//g, '');
+    require('dns').resolve(host, function(err) {
+      if (err) {
+        self.hoodie.emit('warn', 'Error reaching the npm registry: Trying to install from cache');
+        return callback({
+          useCache: true
+        });
+      }
+      self.hoodie.emit('info', 'The npm registry is available');
+      callback();
+    });
+  };
+
+  var latest = function(npm, callback) {
+    var fixture = new StdOutFixture();
+    fixture.capture(function() {
+      return false;
+    });
+
+    npm.info(options.tmpl_cfg.template, function(err, pkg) {
+      fixture.release();
+
+      if (err) {
+        self.hoodie.emit('warn', 'Error getting template info:');
+        self.hoodie.emit('warn', err.message);
+        return callback(err);
+      }
+
+      options.tmpl_cfg.latest = Object.keys(pkg)[0];
+      callback();
+    });
+  };
+
+  var latestCached = function(npm, callback) {
+    var fixture = new StdOutFixture();
+    fixture.capture(function() {
+      return false;
+    });
+
+    npm.commands.cache([
+      'ls',
+      options.tmpl_cfg.template + '@' + options.tmpl_cfg.latest
+    ], function(err, entries) {
+
+      fixture.release();
+
+      if (err) {
+        self.hoodie.emit('warn', 'Error listing npm cache:');
+        self.hoodie.emit('warn', err.message);
+        return callback(err);
+      }
+
+      if (entries.length) {
+        self.hoodie.emit('info', 'Installing from the npm cache');
+        return callback({
+          useCache: true
+        });
+      }
+
+      self.hoodie.emit('info', 'Installing from the npm regitry');
+      return callback();
+    });
+  };
 
   npm.load(options.npmArgs, function(err, npm) {
     if (err) {
@@ -100,7 +163,45 @@ CreateCommand.prototype.fetch = function (options, ctx, callback) {
       return callback(err);
     }
 
-    npm.install(options.tmpl_cfg.template, function(err, deps, pkg) {
+    async.applyEachSeries([
+      registryAvailable,
+      latest,
+      latestCached
+    ], npm, function(err) {
+      if (err && err.useCache) {
+        options.npmArgs['cache-min'] = 1e12;
+        options.npmArgs['no-registry'] = true;
+        return callback();
+      }
+      if (err) {
+        return callback(err);
+      }
+      callback();
+    });
+  });
+
+};
+
+CreateCommand.prototype.fetch = function (options, ctx, callback) {
+
+  var self = ctx;
+
+  self.hoodie.emit('info', 'This may take some time.');
+
+  npm.load(options.npmArgs, function(err, npm) {
+    if (err) {
+      self.hoodie.emit('warn', 'Error loading npm:');
+      self.hoodie.emit('warn', err.message);
+      return callback(err);
+    }
+
+    var pkg = options.tmpl_cfg.template;
+
+    if (options.tmpl_cfg.latest) {
+      pkg += '@' + options.tmpl_cfg.latest;
+    }
+
+    npm.install(pkg, function(err, deps, pkg) {
       if (err) {
         self.hoodie.emit('warn', 'Error installing template:');
         self.hoodie.emit('warn', err.message);
@@ -207,6 +308,7 @@ CreateCommand.prototype.execute = function (options) {
 
   async.applyEachSeries([
     self.mkdir,
+    self.checkCache,
     self.fetch,
     self.copyToCwd,
     self.cleanup,

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "async": "^0.9.0",
     "cli-color": "^0.3.2",
     "colors": "^0.6.2",
+    "fixture-stdout": "^0.2.1",
     "graceful-fs": "^3.0.2",
     "ini": "^1.2.1",
     "insight": "^0.4.1",


### PR DESCRIPTION
As `hoodie new` takes forever (especially when doing repeated integration tests locally) I wrote some logic that forces npm to use the local cache if available.

Unfortunately npm's `--no-registry` command is currently broken, so it doesn't really work (https://github.com/npm/npm/issues/1738, https://github.com/npm/npm/issues/2568) but it will once they fix it, which is high on their agenda. Merging now would do no harm anyways.

Btw, there could be one workaround to make it work now: Create a local webserver that returns an error instantly and set it as npm's registry.

@svnlto 
