### PR TITLE
Make npm registry check pass for people using the registry via HTTP

### DIFF
--- a/lib/hoodie/new.js
+++ b/lib/hoodie/new.js
@@ -92,7 +92,7 @@ CreateCommand.prototype.checkCache = function (options, ctx, callback) {
   var self = ctx;
 
   var registryAvailable = function(npm, callback) {
-    var host = npm.config.get('registry').replace(/https+:\/\/|\//g, '');
+    var host = npm.config.get('registry').replace(/https?:\/\/|\//g, '');
     require('dns').resolve(host, function(err) {
       if (err) {
         self.hoodie.emit('warn', 'Error reaching the npm registry: Trying to install from cache');


### PR DESCRIPTION
This is sometimes a necessary npm config change for people behind corporate firewalls :disappointed: 
