### PR TITLE
refactor(packages): use lodash instead of underscore

### DIFF
--- a/lib/hoodie/util/packages.js
+++ b/lib/hoodie/util/packages.js
@@ -1,7 +1,9 @@
 /*jshint -W079 */
 
 var fs = require('graceful-fs');
-var _ = require('underscore');
+var bind = require('lodash/function/bind');
+var difference = require('lodash/array/difference');
+var union = require('lodash/array/union');
 
 //
 // Modifies the hoodie.plugins property of a package.json file
@@ -35,9 +37,11 @@ exports._modifyPlugins = function (p, transform, callback) {
 //
 
 exports.extendPlugins = function (p, plugins, callback) {
-  return exports._modifyPlugins(p, function (ps) {
-    return _.uniq(ps.concat(plugins));
-  }, callback);
+  return exports._modifyPlugins(
+    p,
+    bind(union, null, plugins),
+    callback
+  );
 };
 
 //
@@ -52,11 +56,11 @@ exports.extendPlugins = function (p, plugins, callback) {
 //
 
 exports.removePlugins = function (p, plugins, callback) {
-  return exports._modifyPlugins(p, function (ps) {
-    return ps.filter(function (plugin) {
-      return !(_.contains(plugins, plugin));
-    });
-  }, callback);
+  return exports._modifyPlugins(
+    p,
+    bind(difference, null, bind.placeholder, plugins),
+    callback
+  );
 };
 
 //

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "graceful-fs": "^3.0.2",
     "ini": "^1.2.1",
     "insight": "^0.4.1",
+    "lodash": "^3.9.1",
     "npm": "^2.1.4",
     "open": "0.0.5",
     "optimist": "^0.6.1",
@@ -18,7 +19,6 @@
     "rimraf": "^2.2.8",
     "semver": "^2.3.2",
     "shelljs": "^0.3.0",
-    "underscore": "^1.6.0",
     "update-notifier": "^0.2.0"
   },
   "engines": {


### PR DESCRIPTION
Hi,

I replaced [underscore](https://github.com/jashkenas/underscore) with [lodash](https://github.com/lodash/lodash).

regards
Christoph