### PR TITLE
Fix for #168: problem installing plugin with full name (eg. hoodie-plugin-email)

### DIFF
--- a/lib/hoodie/install.js
+++ b/lib/hoodie/install.js
@@ -130,15 +130,11 @@ CreateCommand.prototype.execute = function(options, callback) {
         }
 
         self.hoodie.emit('info', 'Successfully installed ' + pluginName + ' plugin');
-        return cb(null, p);
+        return cb(null, fullName);
       });
     },
     function (err, plugins) {
-      var modules = plugins.map(function (name) {
-        return 'hoodie-plugin-' + name;
-      });
-
-      packages.extendPlugins('package.json', modules, function (err) {
+      packages.extendPlugins('package.json', plugins, function (err) {
         if (err) {
           self.hoodie.emit('warn', 'Error updating package.json');
           process.exit(1);


### PR DESCRIPTION
The integration tests failed prior to making this change, and after as well, so I am not 100% sure sure about this change.  The unit tests passed though.  In looking at the existing unit tests, I did not see a reasonable way to attempt to test this change, as it requires actually installing a plugin and then checking the contents of package.json.

But from the command line, I did check the following cases:
hoodie install users,hoodie-plugin-email-verifier
hoodie install users
hoodie install hoodie-plugin-email-verifier
In all cases, package.json looked correct, and the app started up fine.