### PR TITLE
fix(start): don't fail hard if open fails

### DIFF
--- a/lib/hoodie/start.js
+++ b/lib/hoodie/start.js
@@ -110,8 +110,6 @@ CreateCommand.prototype.execute = function(options, callback) {
 
               if (err) {
                 self.hoodie.emit('warn', err.message);
-                process.exit(1);
-                return callback(err);
               }
 
               self.hoodie.emit('info', 'Hoodie app is running!');


### PR DESCRIPTION
remove the hard-fail if `openBrowser()` isn't able to open a browser-window.