### PR TITLE
Project-specific settings for 'hoodie start'

### DIFF
--- a/lib/hoodie/start.js
+++ b/lib/hoodie/start.js
@@ -57,7 +57,9 @@ CreateCommand.prototype.execute = function(options, callback) {
     var project = JSON.parse(fs.readFileSync('./package.json', 'utf-8'));
     var settings = project.hoodie.start;
 
-    if (!settings) throw 'exception';
+    if (!settings) {
+      throw 'exception';
+    }
   }
   catch (e) {
     console.log('Hoodie couldn\'t find any local startup settings');

--- a/lib/hoodie/start.js
+++ b/lib/hoodie/start.js
@@ -51,6 +51,18 @@ CreateCommand.prototype.execute = function(options, callback) {
   var self = this;
   var processArgs = [];
 
+  // get project-specific startup settings from package.json
+  //
+  try {
+    var project = JSON.parse(fs.readFileSync('./package.json', 'utf-8'));
+    var settings = project.hoodie.start;
+
+    if (!settings) throw 'exception';
+  }
+  catch (e) {
+    console.log('Hoodie couldn\'t find any local startup settings');
+  }
+
   // adds ability to bypass sudo check
   //
   if (!options.sudo) {
@@ -71,17 +83,20 @@ CreateCommand.prototype.execute = function(options, callback) {
     }
 
     // serve from custom location
-    if (options.www) {
-      processArgs.push('--www', options.www);
-      self.hoodie.emit('info', 'Serving hoodie from ' + options.www);
-    }
-    // configure custom ports
-    if (options['custom-ports']) {
-      processArgs.push('--custom-ports', options['custom-ports']);
-      self.hoodie.emit('info', 'Serving hoodie on custom ports ' + options['custom-ports']);
+    var www = options.www || settings['root-folder'];
+    if (www) {
+      processArgs.push('--www', www);
+      self.hoodie.emit('info', 'Serving hoodie from ' + www);
     }
 
-    if (options.verbose) {
+    // configure custom ports
+    var ports = options['custom-ports'] || settings['custom-ports'];
+    if (ports) {
+      processArgs.push('--custom-ports', ports);
+      self.hoodie.emit('info', 'Serving hoodie on custom ports ' + ports);
+    }
+
+    if (options.verbose || settings.verbose) {
       processArgs.push('-v');
     }
 
@@ -104,7 +119,8 @@ CreateCommand.prototype.execute = function(options, callback) {
           }
 
           // open hoodie app in browser
-          if (!options.noBrowser) {
+          var openBrowser = settings['open-browser'] || true;
+          if (openBrowser && !options.noBrowser) {
 
             self.openBrowser(msg.stack.www, function (err) {
 


### PR DESCRIPTION
For my own use I found it useful to be able to set some project-specific settings for the behaviour of the `hoodie start` comment. I haven't written any tests yet, but I'm already opening this pull request to see if it's something you'd be interested in merging into the main branch, and, if yes, to already get some possible feedback on my implementation.

This is the behaviour:
- Settings in package.json overwrite the default behaviour of `hoodie start`
- Flags added to the command can still overwrite the behaviour specified in package.json

This is an example of how I currently write the settings in package.json:

```json
"hoodie": {
    "plugins": [ 
        "hoodie-plugin-appconfig",
        "hoodie-plugin-email",
        "hoodie-plugin-users"
    ],
    "start": {
        "root-folder": "./public_html",
        "open-browser": false
    }
}
```